### PR TITLE
Change snowpack meta url to __ instead of _

### DIFF
--- a/demo/snowpack.config.js
+++ b/demo/snowpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     /* ... */
   },
   buildOptions: {
-    /* ... */
+    // the default _snowpack is being ignored by jekyll
+    metaUrlPath: '__snowpack__',
   },
-};
+}


### PR DESCRIPTION
_snowpack is ignored by jekyll on github pages.
Switching to __snowpack fixes the issue.