### PR TITLE
Apply snowpack default config

### DIFF
--- a/demo/snowpack.config.js
+++ b/demo/snowpack.config.js
@@ -16,7 +16,6 @@ module.exports = {
     /* ... */
   },
   buildOptions: {
-    // the default _snowpack is being ignored by jekyll
-    metaUrlPath: '__snowpack__',
+    /* ... */
   },
 }


### PR DESCRIPTION
Do not use custom meta url path.
The meta url path is not required as jekyll is now disabled.