### PR TITLE
Set consistent start state for benchmark

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -77,6 +77,8 @@ const createScene = async function () {
     await setupNonOptimizedScene(scene);
   }
 
+  // notify benchmark when scene is set
+  console.log("::benchmark::loadedModels");
   performance.mark("gltfLoadEnd");
   performance.measure("modelLoading", "gltfLoadStart", "gltfLoadEnd");
   // Return the created scene


### PR DESCRIPTION
Use additional communication to benchmark to enforce consistent state when starting benchmark.
This makes sure that only the actual runtime behavior of the scene is recorded.