### PR TITLE
Extend grundlagen

### DIFF
--- a/documentation/report/parts/theoretische_grundlagen.tex
+++ b/documentation/report/parts/theoretische_grundlagen.tex
@@ -242,7 +242,7 @@ Dies reduziert die Anzahl Polygone drastisch.
 
 \begin{figure}[H]
   \centering
-  \includegraphics[width=0.7\columnwidth]{grundlagen/Camera-Frustum.png}
+  \includegraphics[width=0.5\columnwidth]{grundlagen/Camera-Frustum.png}
   \caption{Kamera Frustum}
   \label{fig:CameraFrustum}
 \end{figure}

--- a/documentation/report/parts/theoretische_grundlagen.tex
+++ b/documentation/report/parts/theoretische_grundlagen.tex
@@ -234,7 +234,7 @@ Visualisierungen können zu komplex werden, um jederzeit performant und interakt
 Insbesondere wenn viele Objekte gleichzeitig sichtbar sind, lohnt es sich Performanzoptimierungen durchzuführen.
 Im Idealfall geschieht dies jedoch, ohne dass der Anwender dies bemerkt.
 
-In diesem Abschnitt werden mögliche Ansätze erklärt, welche helfen sollen, die Render-Perfomanz zu erhöhen. Diese Arbeit konzentriert sich jedoch auf den Ansatz von Level of Detail; die anderen Ansätze werden nur kurz erläutert. Detailliert auf Level of Detail wird in \autoref{chap:lodIntroduction} eingegangen.
+In diesem Abschnitt werden mögliche Ansätze erklärt, welche helfen sollen, die Render-Performanz zu erhöhen. Diese Arbeit konzentriert sich jedoch auf den Ansatz von Level of Detail; die anderen Ansätze werden nur kurz erläutert. Detailliert auf Level of Detail wird in \autoref{chap:lodIntroduction} eingegangen.
 
 \paragraph{Frustum culling}
 Polygone, welche nicht im Kamera Frustum enthalten sind, werden bei dieser Methode nicht weiter prozessiert.
@@ -272,7 +272,7 @@ In gewissen Fällen kann das Modellieren übersprungen werden. So kann anhand vo
 Als Level Of Detail (LOD) werden die verschiedenen Detailstufen bei der virtuellen Darstellung bezeichnet.
 Dies wird verwendet, um die Geschwindigkeit von Anwendungen zu steigern, indem Objekte im Nahbereich detailiert angezeigt werden; wohingegen Elemente im Fernbereich deutlich vereinfacht dargestellt werden.
 
-Ein LOD Algorithmus hat das Ziel für ein gegebenes Modell eine vereinfachte Darstellung zu finden, welche das Original ausreichend annähert. Um diese Approximationen zu generieren kann eine Vielzahl von Algorithmen verwendet werden. Es gibt verschiedene Ansätze zur Generierung von LODs, welche in \autoref{chap:lodAlgorithmComparison} im Detail erläutert werden.
+Ein LOD Algorithmus hat das Ziel für ein gegebenes Modell eine vereinfachte Darstellung zu finden, welche das Original ausreichend annähert. Um diese Approximationen zu generieren, kann eine Vielzahl von Algorithmen verwendet werden. Es gibt verschiedene Ansätze zur Generierung von LODs, welche in \autoref{chap:lodAlgorithmComparison} im Detail erläutert werden.
 
 \begin{figure}[H]
 \centering
@@ -281,7 +281,7 @@ Ein LOD Algorithmus hat das Ziel für ein gegebenes Modell eine vereinfachte Dar
 \label{fig:LevelOfDetailVisualisierungvierHasen}
 \end{figure}
 
-Wie in der Abbildung \ref{fig:LevelOfDetailVisualisierungvierHasen} zu erkennen ist, wird von links nach rechts der Detailgrad und somit die Komplexität des Objektes reduziert. Sind es im Bild ganz links noch 69'451 Polygone, wird es bereits im ersten Schritt auf 2'502 Polygone reduziert. Dies ist eine enorme Reduktion von ca 96.5\%. Im dritten Schritt wird die Anzahl Polygone wiederum um ca. 90\% auf 251 reduziert. Schlussendlich hat das letzte Objekt noch 76 Polygone was knapp 0.1\% der ursprünglichen Anzahl entspricht.
+Wie in der Abbildung \ref{fig:LevelOfDetailVisualisierungvierHasen} zu erkennen ist, wird von links nach rechts der Detailgrad und somit die Komplexität des Objektes reduziert. Sind es im Bild ganz links noch 69'451 Polygone, wird es bereits im ersten Schritt auf 2'502 Polygone reduziert. Dies ist eine enorme Reduktion von ca. 96.5\%. Im dritten Schritt wird die Anzahl Polygone wiederum um ca. 90\% auf 251 reduziert. Schlussendlich hat das letzte Objekt noch 76 Polygone was knapp 0.1\% der ursprünglichen Anzahl entspricht.
 
 \subsection{Ansätze für LOD Artefakte}
 \label{chap:differentLodApproaches}
@@ -314,7 +314,7 @@ Grundsätzlich kann man die verschiedenen Algorithmen in Kategorien einteilen.
 Im folgenden Abschnitt wird auf die Grundidee der verschiedenen Kategorien eingegangen.
 
 \paragraph{Vertex Dezimierung}
-Algorithmen dieser Kategorie entfernen jeweils einen Vertex und triangluieren das entstehende Loch neu.
+Algorithmen dieser Kategorie entfernen jeweils einen Vertex und triangulieren das entstehende Loch neu.
 Eine weitere Möglichkeit ist das \e{Vertex Clustering}, hierbei wird ein Modell in verschiedene Gitterzellen aufgeteilt. Die Punkte innerhalb einer Gitterzelle werden dann in einen einzigen Punkt zusammengelegt. Die visuelle Annäherung dieser Algorithmen bei drastischen Vereinfachungen stellt jedoch häufig ein Problem dar für polygonale Modelle. Sogenannte \fglspl{Point Cloud}{Vertices im dreidimensionalen Raum ohne zugehörige \e{Triangle}}, wie sie bei 3D-Scannern eingesetzt werden, können mit solchen Algorithmen schnell vereinfacht werden.
 
 \paragraph{Edge Collapse}

--- a/documentation/report/parts/theoretische_grundlagen.tex
+++ b/documentation/report/parts/theoretische_grundlagen.tex
@@ -272,7 +272,7 @@ In gewissen Fällen kann das Modellieren übersprungen werden. So kann anhand vo
 Als Level Of Detail (LOD) werden die verschiedenen Detailstufen bei der virtuellen Darstellung bezeichnet.
 Dies wird verwendet, um die Geschwindigkeit von Anwendungen zu steigern, indem Objekte im Nahbereich detailiert angezeigt werden; wohingegen Elemente im Fernbereich deutlich vereinfacht dargestellt werden.
 
-Um diese Approximationen zu generieren kann eine Vielzahl von Algorithmen verwendet werden. Dieses Problem ist bekannt als polygonale Simplifizierung, geometrische Simplifizierung oder Mesh Reduzierung. Es gibt verschiedene Ansätze zur Generierung von LODs, welche in Abschnitt XY im Detail erläutert werden. Zudem braucht es eine berechenbare Methode, die Genauigkeit von Modellen zu definieren, um diese entsprechend anzuwenden. Schlussendlich ist dann noch zu definieren, ab wann welche Artefakte verwendet werden soll, basierend auf der Genauigkeit und der Komplexität.
+Ein LOD Algorithmus hat das Ziel für ein gegebenes Modell eine vereinfachte Darstellung zu finden, welche das Original ausreichend annähert. Um diese Approximationen zu generieren kann eine Vielzahl von Algorithmen verwendet werden. Es gibt verschiedene Ansätze zur Generierung von LODs, welche in \autoref{chap:lodAlgorithmComparison} im Detail erläutert werden.
 
 \begin{figure}[H]
 \centering
@@ -282,8 +282,6 @@ Um diese Approximationen zu generieren kann eine Vielzahl von Algorithmen verwen
 \end{figure}
 
 Wie in der Abbildung \ref{fig:LevelOfDetailVisualisierungvierHasen} zu erkennen ist, wird von links nach rechts der Detailgrad und somit die Komplexität des Objektes reduziert. Sind es im Bild ganz links noch 69'451 Polygone, wird es bereits im ersten Schritt auf 2'502 Polygone reduziert. Dies ist eine enorme Reduktion von ca 96.5\%. Im dritten Schritt wird die Anzahl Polygone wiederum um ca. 90\% auf 251 reduziert. Schlussendlich hat das letzte Objekt noch 76 Polygone was knapp 0.1\% der ursprünglichen Anzahl entspricht.
-
-
 
 \subsection{Ansätze für LOD Artefakte}
 \label{chap:differentLodApproaches}
@@ -307,3 +305,21 @@ Bei HLOD werden mehrere Objekte in einen Cluster gruppiert.
 Diese Methode erlaubt es somit zum Beispiel Terrains optimal abzubilden. So werden Ausschnitte, welche nahe beim Benutzer sind mit hoher Auflösung dargestellt während weiter entferntere Teile der Umgebung mit weniger Details ausgestattet sind.
 Zudem ist es möglich viele kleinere Objekte bei entsprechenden Distanzen zu kombinieren.
 Der Hauptnachteil liegt darin, dass hierfür signifikante Anpassungen am Scene Graph notwendig sind und für den Entwickler ein spürbarer Unterschied entstehen kann.
+
+\subsection{Vergleich Algorithmen}
+\label{chap:lodAlgorithmComparison}
+
+Diese Art von Problem ist in der Literatur unter anderem als \e{Surface Simplification}, polygonale Simplifizierung, geometrische Simplifizierung oder Mesh Reduzierung bekannt.
+Grundsätzlich kann man die verschiedenen Algorithmen in Kategorien einteilen.
+Im folgenden Abschnitt wird auf die Grundidee der verschiedenen Kategorien eingegangen.
+
+\paragraph{Vertex Dezimierung}
+Algorithmen dieser Kategorie entfernen jeweils einen Vertex und triangluieren das entstehende Loch neu.
+Eine weitere Möglichkeit ist das \e{Vertex Clustering}, hierbei wird ein Modell in verschiedene Gitterzellen aufgeteilt. Die Punkte innerhalb einer Gitterzelle werden dann in einen einzigen Punkt zusammengelegt. Die visuelle Annäherung dieser Algorithmen bei drastischen Vereinfachungen stellt jedoch häufig ein Problem dar für polygonale Modelle. Sogenannte \fglspl{Point Cloud}{Vertices im dreidimensionalen Raum ohne zugehörige \e{Triangle}}, wie sie bei 3D-Scannern eingesetzt werden, können mit solchen Algorithmen schnell vereinfacht werden.
+
+\paragraph{Edge Collapse}
+Hierbei werden iterativ \e{Edges} entfernt und die beiden \e{Vertices} zu einem Punkt zusammengelegt.
+Die verschiedenen Algorithmen unterscheiden sich primär in der Selektion der \e{Edges}. Grundsätzlich wird hierfür eine Heuristik verwendet um den Fehler quantifizieren zu können. Anschliessend werden iterativ die \e{Edges} entfernt, welche zu einem minimalen Fehler führen. Beim Zusammenführen von \e{Edges} sind abhängig vom gewählten LOD System unterschiedliche Strategien gefordert. Bei diskreten LOD Systemen soll nach dem Zusammenführen ein optimaler neuer Punkt gefunden werden, bei kontinuierlichen LOD Systemen wird häufig einer der beiden Punkte gewählt um Speicherplatz einsparen zu können.
+
+\paragraph{Face Collapse}
+Bei dieser Variante werden jeweils Flächen entfernt und die umliegenden Flächen zusammengelegt.

--- a/documentation/report/parts/theoretische_grundlagen.tex
+++ b/documentation/report/parts/theoretische_grundlagen.tex
@@ -229,29 +229,12 @@ Im letzten Schritt werden kontinuierliche Objekte zu diskreten Fragmenten verarb
 \paragraph{Bildschirm}
 Am Schluss wird das vom Rasterization Prozess generierte Bild auf dem Bildschirm dargestellt.
 
-\section{Einführung LOD}
-Als Level Of Detail (LOD) werden die verschiedenen Detailstufen bei der virtuellen Darstellung bezeichnet.
-Dies wird verwendet, um die Geschwindigkeit von Anwendungen zu steigern, indem Objekte im Nahbereich detailiert angezeigt werden; wohingegen Elemente im Fernbereich deutlich vereinfacht dargestellt werden.
-
-\subsection{Das Problem}
-Modelle können zu komplex werden, um jederzeit performant und interaktiv gerendert zu werden.
-Insbesondere wenn viele Objekte gleichzeitig sichtbar sind, lohnt es sich, zu priorisieren und gewisse Objekte in reduzierter Qualität anzuzeigen.
+\section{Performanzoptimierung}
+Visualisierungen können zu komplex werden, um jederzeit performant und interaktiv gerendert zu werden.
+Insbesondere wenn viele Objekte gleichzeitig sichtbar sind, lohnt es sich Performanzoptimierungen durchzuführen.
 Im Idealfall geschieht dies jedoch, ohne dass der Anwender dies bemerkt.
 
-\subsection{Lösungsansätze}
-In diesem Abschnitt werden mögliche Ansätze erklärt, welche helfen sollen, die Render-Perfomanz zu erhöhen. Diese Arbeit konzentriert sich jedoch auf den Ansatz von Level of Detail; die anderen Ansätze werden nur kurz erläutert.
-
-\paragraph{Level of Detail}
-Level of Detail auch bekannt als polygonale Simplifizierung, geometrische Simplifizierung oder Mesh Reduzierung basiert darauf, die Komplexität von Objekten zu reduzieren, welche weiter von der Kamera entfernt sind. Es gibt verschiedene Ansätze zur Generierung von LODs, welche in Abschnitt XY im Detail erläutert werden. Zudem braucht es eine berechenbare Methode, die Genauigkeit von Modellen zu definieren, um diese entsprechend anzuwenden. Schlussendlich ist dann noch zu definieren, ab wann welche Artefakte verwendet werden soll, basierend auf der Genauigkeit und der Komplexität.
-
-\begin{figure}[H]
-\centering
-\includegraphics[width=0.8\columnwidth]{LODs-of-a-bunny-model-Courtesy-Stanford-3D-Scanning-Repository-From-left-to-right}
-\caption{Level Of Detail Visualisierung vier Hasen}
-\label{fig:LevelOfDetailVisualisierungvierHasen}
-\end{figure}
-
-Wie in der Abbildung \ref{fig:LevelOfDetailVisualisierungvierHasen} zu erkennen ist, wird von links nach rechts der Detailgrad und somit die Komplexität des Objektes reduziert. Sind es im Bild ganz links noch 69'451 Polygone, wird es bereits im ersten Schritt auf 2'502 Polygone reduziert. Dies ist eine enorme Reduktion von ca 96.5\%. Im dritten Schritt wird die Anzahl Polygone wiederum um ca. 90\% auf 251 reduziert. Schlussendlich hat das letzte Objekt noch 76 Polygone was knapp 0.1\% der ursprünglichen Anzahl entspricht.
+In diesem Abschnitt werden mögliche Ansätze erklärt, welche helfen sollen, die Render-Perfomanz zu erhöhen. Diese Arbeit konzentriert sich jedoch auf den Ansatz von Level of Detail; die anderen Ansätze werden nur kurz erläutert. Detailliert auf Level of Detail wird in \autoref{chap:lodIntroduction} eingegangen.
 
 \paragraph{Frustum culling}
 Polygone, welche nicht im Kamera Frustum enthalten sind, werden bei dieser Methode nicht weiter prozessiert.
@@ -283,6 +266,24 @@ Auch bekannt unter Distributed Rendering ist der Einsatz von Techniken aus dem P
 
 \paragraph{Image-based rendering}
 In gewissen Fällen kann das Modellieren übersprungen werden. So kann anhand von Bildmaterial eine 3D-Illusion erzeugt werden.
+
+\section{Einführung Level of Detail}
+\label{chap:lodIntroduction}
+Als Level Of Detail (LOD) werden die verschiedenen Detailstufen bei der virtuellen Darstellung bezeichnet.
+Dies wird verwendet, um die Geschwindigkeit von Anwendungen zu steigern, indem Objekte im Nahbereich detailiert angezeigt werden; wohingegen Elemente im Fernbereich deutlich vereinfacht dargestellt werden.
+
+Um diese Approximationen zu generieren kann eine Vielzahl von Algorithmen verwendet werden. Dieses Problem ist bekannt als polygonale Simplifizierung, geometrische Simplifizierung oder Mesh Reduzierung. Es gibt verschiedene Ansätze zur Generierung von LODs, welche in Abschnitt XY im Detail erläutert werden. Zudem braucht es eine berechenbare Methode, die Genauigkeit von Modellen zu definieren, um diese entsprechend anzuwenden. Schlussendlich ist dann noch zu definieren, ab wann welche Artefakte verwendet werden soll, basierend auf der Genauigkeit und der Komplexität.
+
+\begin{figure}[H]
+\centering
+\includegraphics[width=0.8\columnwidth]{LODs-of-a-bunny-model-Courtesy-Stanford-3D-Scanning-Repository-From-left-to-right}
+\caption{Level Of Detail Visualisierung vier Hasen}
+\label{fig:LevelOfDetailVisualisierungvierHasen}
+\end{figure}
+
+Wie in der Abbildung \ref{fig:LevelOfDetailVisualisierungvierHasen} zu erkennen ist, wird von links nach rechts der Detailgrad und somit die Komplexität des Objektes reduziert. Sind es im Bild ganz links noch 69'451 Polygone, wird es bereits im ersten Schritt auf 2'502 Polygone reduziert. Dies ist eine enorme Reduktion von ca 96.5\%. Im dritten Schritt wird die Anzahl Polygone wiederum um ca. 90\% auf 251 reduziert. Schlussendlich hat das letzte Objekt noch 76 Polygone was knapp 0.1\% der ursprünglichen Anzahl entspricht.
+
+
 
 \subsection{Ansätze für LOD Artefakte}
 \label{chap:differentLodApproaches}

--- a/documentation/report/parts/vorgehen_methoden.tex
+++ b/documentation/report/parts/vorgehen_methoden.tex
@@ -111,9 +111,9 @@ Der Algorithmus kann wie folgt zusammengefasst werden:
 \subsection{Fehler Metrik}
 Das Ziel der Fehler Metrik ist es eine Heuristik zu definieren, welche den geometrischen Unterschied zwischen dem vereinfachten und dem originalen Modell beschreibt.
 Mithilfe der Fehler Metrik können anschliessend die Transformationen am Modell gemäss den kleinsten Kosten optimiert werden. Der Algorithmus funktioniert grundsätzlich unabhängig von der gewählten Fehler Metrik. So könnten verschiedene Metriken eingesetzt werden.
-Die hier gewählte Metrik definiert den Fehler mithilfe einer symmetrischen 4x4 Matrix. Die Matrix repräsentiert die Distanz eines \e{Vertices} zu einer zugehörigen \e{Face}. Für die Kombination mehrerer \e{Faces} können die Matrizen addiert werden.
+Die hier gewählte Metrik definiert den Fehler mithilfe einer symmetrischen 4×4 Matrix. Die Matrix repräsentiert die Distanz eines \e{Vertices} zu einer zugehörigen \e{Face}. Für die Kombination mehrerer \e{Faces} können die Matrizen addiert werden.
 
-Beim entfernen einer \e{Edge} werden die Fehler Metriken der zugehörigen \e{Vertices} addiert.
+Beim Entfernen einer \e{Edge} werden die Fehler Metriken der zugehörigen \e{Vertices} addiert.
 
 \section{Pipeline Integration}
 Die Lösung soll in eine wiederverwendbare und konfigurierbare Pipeline integriert werden.

--- a/documentation/report/parts/vorgehen_methoden.tex
+++ b/documentation/report/parts/vorgehen_methoden.tex
@@ -94,10 +94,19 @@ Eine Übersicht über die verschiedenen Kriterien kann in Tabelle \ref{table:lod
   \label{table:lodSystemComparison}
 \end{table}
 
-\section{Vergleich LOD Algorithmen}
-Die verschiedenen Klassen von Algorithmen werden in \autoref{chap:lodAlgorithmComparison} kurz erläutrt.
-Die wohl weitverbreiteste Art ist die von Garland und Heckbert 1997 definierte \e{Surface Simplification using Quadric Error Metrics}.
+\section{Surface Simplification Algorithmus}
+Die verschiedenen Klassen von Algorithmen werden in \autoref{chap:lodAlgorithmComparison} kurz erläutert.
+
+Verschiedene Algorithmen wurden für die Implementierung in Betracht gezogen. Die wohl weitverbreiteste Art ist der von Garland und Heckbert 1997 definierte \e{Surface Simplification using Quadric Error Metrics} welcher auf \e{Edge Collapses} basiert.
 \cite{surfaceSimplificationUsingQuadricErrorMetrices}
+
+Der Algorithmus kann wie folgt zusammengefasst werden:
+
+\begin{enumerate}
+  \item Fehler Metrik für alle Vertices berechnen.
+  \item Optionen für \e{Edge Collapse} markieren.
+  \item Optionen mit geringstem Fehler optimieren.
+\end{enumerate}
 
 \section{Pipeline Integration}
 Die Lösung soll in eine wiederverwendbare und konfigurierbare Pipeline integriert werden.

--- a/documentation/report/parts/vorgehen_methoden.tex
+++ b/documentation/report/parts/vorgehen_methoden.tex
@@ -108,6 +108,13 @@ Der Algorithmus kann wie folgt zusammengefasst werden:
   \item Optionen mit geringstem Fehler optimieren.
 \end{enumerate}
 
+\subsection{Fehler Metrik}
+Das Ziel der Fehler Metrik ist es eine Heuristik zu definieren, welche den geometrischen Unterschied zwischen dem vereinfachten und dem originalen Modell beschreibt.
+Mithilfe der Fehler Metrik können anschliessend die Transformationen am Modell gemäss den kleinsten Kosten optimiert werden. Der Algorithmus funktioniert grundsätzlich unabhängig von der gewählten Fehler Metrik. So könnten verschiedene Metriken eingesetzt werden.
+Die hier gewählte Metrik definiert den Fehler mithilfe einer symmetrischen 4x4 Matrix. Die Matrix repräsentiert die Distanz eines \e{Vertices} zu einer zugehörigen \e{Face}. Für die Kombination mehrerer \e{Faces} können die Matrizen addiert werden.
+
+Beim entfernen einer \e{Edge} werden die Fehler Metriken der zugehörigen \e{Vertices} addiert.
+
 \section{Pipeline Integration}
 Die Lösung soll in eine wiederverwendbare und konfigurierbare Pipeline integriert werden.
 In der Webentwicklung ist es üblich, über \fgls{CLI}{Command Line Interface – Kommandozeile} Arbeitsschritte zu automatisieren. Es soll demnach ein \e{\gls{CLI}} erstellt und auf \fgls{NPM}{Node Package Manager} öffentlich zugänglich gemacht werden, welches nahtlos in den Entwicklungsablauf integriert werden kann. Über eine Konfiguration soll angegeben werden können, wo nach den \e{.glTF} Dateien gesucht, wie die Output-Dateien benennt und in welchem Modus das Tool gestartet werden soll. Ebenso werden Algorithmus-Einstellungen in dieser Konfiguration gesetzt werden können. Es soll einfach zu bedienen, gut dokumentiert und gut gewählte Standardeinstellungen haben. Zudem soll das Tool im einmal Modus laufen können oder kontinuierlich sich ändernde Dateien neu optimieren.

--- a/documentation/report/parts/vorgehen_methoden.tex
+++ b/documentation/report/parts/vorgehen_methoden.tex
@@ -95,22 +95,9 @@ Eine Übersicht über die verschiedenen Kriterien kann in Tabelle \ref{table:lod
 \end{table}
 
 \section{Vergleich LOD Algorithmen}
-Ein LOD Algorithmus hat das Ziel für ein gegebenes Modell eine vereinfachte Darstellung zu finden, welche das Original ausreichend annähert.
-Diese Art von Problem ist in der Literatur unter anderem als \e{Surface Simplification} bekannt.
+Die verschiedenen Klassen von Algorithmen werden in \autoref{chap:lodAlgorithmComparison} kurz erläutrt.
 Die wohl weitverbreiteste Art ist die von Garland und Heckbert 1997 definierte \e{Surface Simplification using Quadric Error Metrics}.
 \cite{surfaceSimplificationUsingQuadricErrorMetrices}
-Im folgenden Abschnitt wird auf verschiedene Lösungsansätze eingegangen.
-
-\paragraph{Vertex Dezimierung}
-Algorithmen dieser Kategorie entfernen jeweils einen Vertex und triangluieren das entstehende Loch neu.
-Eine weitere Möglichkeit ist das \e{Vertex Clustering}, hierbei wird ein Modell in verschiedene Gitterzellen aufgeteilt. Die Punkte innerhalb einer Gitterzelle werden dann in einen einzigen Punkt zusammengelegt. Die visuelle Annäherung dieser Algorithmen bei drastischen Vereinfachungen stellt jedoch häufig ein Problem dar für polygonale Modelle. Sogenannte \fglspl{Point Cloud}{Vertices im dreidimensionalen Raum ohne zugehörige \e{Triangle}}, wie sie bei 3D-Scannern eingesetzt werden, können mit solchen Algorithmen schnell vereinfacht werden.
-
-\paragraph{Edge Collapse}
-Hierbei werden iterativ \e{Edges} entfernt und die beiden \e{Vertices} zu einem Punkt zusammengelegt.
-Die verschiedenen Algorithmen unterscheiden sich primär in der Selektion der \e{Edges}. Grundsätzlich wird hierfür eine Heuristik verwendet um den Fehler quantifizieren zu können. Anschliessend werden iterativ die \e{Edges} entfernt, welche zu einem minimalen Fehler führen. Beim Zusammenführen von \e{Edges} sind abhängig vom gewählten LOD System unterschiedliche Strategien gefordert. Bei diskreten LOD Systemen soll nach dem Zusammenführen ein optimaler neuer Punkt gefunden werden, bei kontinuierlichen LOD Systemen wird häufig einer der beiden Punkte gewählt um Speicherplatz einsparen zu können.
-
-\paragraph{Face Collapse}
-Bei dieser Variante werden jeweils Flächen entfernt und die umliegenden Flächen zusammengelegt.
 
 \section{Pipeline Integration}
 Die Lösung soll in eine wiederverwendbare und konfigurierbare Pipeline integriert werden.


### PR DESCRIPTION
Primarily restructure the content.
Move the different kinds of optimisations (such as frustum culling, …) to a separate section as they have nothing to do with LODs and should therefore not be part of "LOD introduction".