### PR TITLE
Calculate confidence interval

### DIFF
--- a/benchmark/stats.js
+++ b/benchmark/stats.js
@@ -1,0 +1,16 @@
+export const calculateNinetyFiveConfidenceInterval = ({
+  mean,
+  variance,
+  samples,
+}) => {
+  const x = mean;
+  const zUpper = 1.96;
+  const zLower = -zUpper;
+  const standardDeviation = Math.sqrt(variance);
+  const n = Math.sqrt(samples);
+
+  return {
+    upper: x + zUpper * (standardDeviation / n),
+    lower: x + zLower * (standardDeviation / n),
+  };
+};

--- a/benchmark/stats.test.js
+++ b/benchmark/stats.test.js
@@ -1,0 +1,14 @@
+import { calculateNinetyFiveConfidenceInterval } from "./stats.js";
+
+describe("calculateNinetyFiveConfidenceInterval", () => {
+  it("should calculate confidence interval", () => {
+    const { upper, lower } = calculateNinetyFiveConfidenceInterval({
+      mean: 30,
+      variance: 300,
+      samples: 100,
+    });
+
+    expect(lower).toBeCloseTo(26.605, 2);
+    expect(upper).toBeCloseTo(33.394, 2);
+  });
+});


### PR DESCRIPTION
Add statistical approach to ensure that results are meaningful.
The current approach uses a 95% confidence interval
this should be sufficient and helps to interpret the benchmark results.

![image](https://user-images.githubusercontent.com/2353772/115767233-2fb31c80-a3a9-11eb-9245-2f859072894c.png)
