### PR TITLE
Only clear specific measure for fps

### DIFF
--- a/demo/src/measure-fps.js
+++ b/demo/src/measure-fps.js
@@ -5,7 +5,7 @@ export function measureFPS() {
   performance.measure(measureName, markerName);
   const performanceEntry = performance.getEntriesByName(measureName)[0];
   const timeSinceLastFrame = performanceEntry.duration;
-  performance.clearMeasures();
+  performance.clearMeasures(measureName);
   performance.mark(markerName);
   return 1 / (timeSinceLastFrame / 1000);
 }


### PR DESCRIPTION
This cleared measures used by the benchmark for general information.
Previously all entries were discarded.