### PR TITLE
Configure workspace root for snowpack

### DIFF
--- a/demo/snowpack.config.js
+++ b/demo/snowpack.config.js
@@ -3,6 +3,7 @@
 
 /** @type {import("snowpack").SnowpackUserConfig } */
 module.exports = {
+  workspaceRoot: "..",
   mount: {
     /* ... */
   },


### PR DESCRIPTION
This permits snowpack to detect changes on locally
imported packages such as three-lode.
Therefore hmr is now enabled nicely for the runtime package.
Kudos to @sir-marc.