### PR TITLE
Reduce the amount of benchmark logs

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,8 @@ The benchmark expects `../demo` project to be running.
 
 The benchmark will automatically run a number of samples, to customize the amount of samples, pass `--iterations=n`.
 
-Interpreting the data is currently wip but the logs give an indication of what is already being tracked.
+By default the benchmark will only show the report. In order to show more detailed information which is helpful for debugging pass `--logDetails`.
+This will log more information from the demo scene.
 
 ## Dev
 Run `yarn setup` to get up and running and then `yarn start`

--- a/benchmark/src/helpers.js
+++ b/benchmark/src/helpers.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { logDetail } from "./logger.js";
 
 export const startTimer = () => {
   const start = process.hrtime.bigint();
@@ -18,11 +19,11 @@ export const waitFor = async (ms) => {
 
 export const startLogGroup = (group) => {
   const stopTimer = startTimer();
-  console.log(group + " started");
+  logDetail(group + " started");
 
   return () => {
     const diff = stopTimer();
-    console.log(group + " ended, duration: " + diff + "ns");
+    logDetail(group + " ended, duration: " + diff + "ns");
   };
 };
 

--- a/benchmark/src/index.js
+++ b/benchmark/src/index.js
@@ -6,14 +6,18 @@ import { hideBin } from "yargs/helpers";
 import { waitFor, startLogGroup, createFolderIfNotExist } from "./helpers.js";
 import { reporter, analyzeTraceEvents, generateReport } from "./analyze.js";
 import { calculateNinetyFiveConfidenceInterval } from "./stats.js";
+import { logDetail, setLogDetail } from "./logger.js";
 
 const argv = yargs(hideBin(process.argv)).argv;
 
 const SAMPLE_TIMEOUT_MS = 20000;
 
+const LOG_DETAILS = argv.logDetails || false;
+setLogDetail(LOG_DETAILS);
+
 const main = async () => {
   const ITERATIONS = argv.iterations || 10;
-  console.log("start benchmark with " + ITERATIONS + " iterations");
+  logDetail("start benchmark with " + ITERATIONS + " iterations");
   const reports = [];
   for (let i = 0; i < ITERATIONS; i++) {
     const optimizedReport = await Promise.any([
@@ -123,7 +127,7 @@ const main = async () => {
 const sample = async (optimize) => {
   const TEMP_FOLDER = "tmp/";
   createFolderIfNotExist(TEMP_FOLDER);
-  console.log("start benchmark");
+  logDetail("start benchmark");
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
 
@@ -142,7 +146,7 @@ const sample = async (optimize) => {
     } else if (log.includes("::benchmark::")) {
       report(log);
     } else {
-      console.info("web-console: " + message.text());
+      logDetail("web-console: " + message.text());
     }
   });
 
@@ -181,9 +185,9 @@ const sample = async (optimize) => {
   });
 
   await browser.close();
-  console.log("stop benchmark");
+  logDetail("stop benchmark");
 
-  console.log("start analyzer");
+  logDetail("start analyzer");
 
   const trace = JSON.parse(fs.readFileSync(`${TEMP_FOLDER}trace.json`, "utf8"));
   const events = trace.traceEvents ? trace.traceEvents : trace;

--- a/benchmark/src/logger.js
+++ b/benchmark/src/logger.js
@@ -1,0 +1,20 @@
+let logDetails = null;
+
+export const setLogDetail = (flag) => {
+  if (logDetails !== null) {
+    throw new Error("logDetail may only be set once");
+  }
+  logDetails = flag;
+};
+
+export const logDetail = (...args) => {
+  if (logDetails === null) {
+    throw new Error(
+      "logDetail is not initialized, make sure to set flag before calling logger."
+    );
+  }
+
+  if (logDetails) {
+    console.log(...args);
+  }
+};


### PR DESCRIPTION
Add log detail approach for benchmark.
This makes the benchmark only log the report by default.
If desired one can still use --logDetails to get more detailed info.