### PR TITLE
Fix camera absolute position

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -122,12 +122,13 @@ const createScene = async function () {
   return scene;
 };
 
-let timeSinceLastUpdate = performance.now();
+let timeSinceLastUpdate = 0;
 let direction = -1;
 function updateCameraPosition() {
-  const delta = performance.now() - timeSinceLastUpdate;
+  const now = performance.now();
+  const delta = now - timeSinceLastUpdate;
   camera.position.z += (delta / 60) * direction;
-  timeSinceLastUpdate = performance.now();
+  timeSinceLastUpdate = now;
   if (camera.position.z > config.cameraConstraints.max) {
     direction = -1;
   } else if (camera.position.z < config.cameraConstraints.min) {


### PR DESCRIPTION
If timeSinceLastUpdate is initialized with performance.now the camera position will be in favor of the version which has longer model load duration.
By initialising timeSinceLastUpdate with 0 we ensure to not give any variant a head start.
Storing performance.now in a variable makes it also marginally fairer and cleaner in general.

