### PR TITLE
Reduce reference memory by reinitialising tStart

### DIFF
--- a/cli/lib/simplification/build-reference-list.js
+++ b/cli/lib/simplification/build-reference-list.js
@@ -1,6 +1,11 @@
 import Reference from "./types/reference.js";
 
 const buildReferenceList = (vertices, triangles) => {
+  vertices.forEach((vertex) => {
+    vertex.tCount = 0;
+    vertex.tStart = 0;
+  });
+
   // init reference counters
   triangles.forEach((triangle) => {
     triangle.vertices.forEach((vertexIndex) => {

--- a/cli/test-data/snapshot/processed-data-structure.json
+++ b/cli/test-data/snapshot/processed-data-structure.json
@@ -45,7 +45,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 12,
+      "tStart": 6,
       "tCount": 6
     },
     {
@@ -69,7 +69,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 24,
+      "tStart": 12,
       "tCount": 6
     },
     {
@@ -93,7 +93,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 37,
+      "tStart": 18,
       "tCount": 8
     },
     {
@@ -117,7 +117,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 57,
+      "tStart": 26,
       "tCount": 7
     },
     {
@@ -141,7 +141,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 71,
+      "tStart": 33,
       "tCount": 10
     },
     {
@@ -165,7 +165,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 91,
+      "tStart": 43,
       "tCount": 7
     },
     {
@@ -189,7 +189,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 105,
+      "tStart": 50,
       "tCount": 3
     },
     {
@@ -213,7 +213,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 111,
+      "tStart": 53,
       "tCount": 2
     },
     {
@@ -237,7 +237,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 115,
+      "tStart": 55,
       "tCount": 2
     },
     {
@@ -261,7 +261,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 119,
+      "tStart": 57,
       "tCount": 4
     },
     {
@@ -285,7 +285,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 127,
+      "tStart": 61,
       "tCount": 6
     },
     {
@@ -309,7 +309,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 139,
+      "tStart": 67,
       "tCount": 5
     },
     {
@@ -333,7 +333,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 149,
+      "tStart": 72,
       "tCount": 3
     },
     {
@@ -357,7 +357,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 155,
+      "tStart": 75,
       "tCount": 5
     },
     {
@@ -381,7 +381,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 165,
+      "tStart": 80,
       "tCount": 2
     },
     {
@@ -405,7 +405,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 169,
+      "tStart": 82,
       "tCount": 2
     },
     {
@@ -429,7 +429,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 180,
+      "tStart": 84,
       "tCount": 5
     },
     {
@@ -453,7 +453,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 190,
+      "tStart": 89,
       "tCount": 3
     },
     {
@@ -477,7 +477,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 196,
+      "tStart": 92,
       "tCount": 6
     },
     {
@@ -501,7 +501,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 208,
+      "tStart": 98,
       "tCount": 5
     },
     {
@@ -525,7 +525,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1265,
+      "tStart": 615,
       "tCount": 5
     },
     {
@@ -549,7 +549,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 226,
+      "tStart": 107,
       "tCount": 5
     },
     {
@@ -573,7 +573,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 236,
+      "tStart": 112,
       "tCount": 4
     },
     {
@@ -597,7 +597,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 245,
+      "tStart": 116,
       "tCount": 5
     },
     {
@@ -621,7 +621,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 255,
+      "tStart": 121,
       "tCount": 6
     },
     {
@@ -645,7 +645,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 267,
+      "tStart": 127,
       "tCount": 5
     },
     {
@@ -669,7 +669,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 277,
+      "tStart": 132,
       "tCount": 7
     },
     {
@@ -693,7 +693,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 291,
+      "tStart": 139,
       "tCount": 5
     },
     {
@@ -717,7 +717,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 302,
+      "tStart": 144,
       "tCount": 2
     },
     {
@@ -741,7 +741,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 306,
+      "tStart": 146,
       "tCount": 2
     },
     {
@@ -765,7 +765,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 310,
+      "tStart": 148,
       "tCount": 2
     },
     {
@@ -789,7 +789,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 314,
+      "tStart": 150,
       "tCount": 3
     },
     {
@@ -813,7 +813,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1270,
+      "tStart": 620,
       "tCount": 8
     },
     {
@@ -837,7 +837,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 330,
+      "tStart": 158,
       "tCount": 5
     },
     {
@@ -861,7 +861,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 340,
+      "tStart": 163,
       "tCount": 6
     },
     {
@@ -885,7 +885,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 352,
+      "tStart": 169,
       "tCount": 6
     },
     {
@@ -909,7 +909,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 364,
+      "tStart": 175,
       "tCount": 5
     },
     {
@@ -933,7 +933,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 375,
+      "tStart": 180,
       "tCount": 5
     },
     {
@@ -957,7 +957,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 385,
+      "tStart": 185,
       "tCount": 5
     },
     {
@@ -981,7 +981,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 395,
+      "tStart": 190,
       "tCount": 6
     },
     {
@@ -1005,7 +1005,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 407,
+      "tStart": 196,
       "tCount": 3
     },
     {
@@ -1029,7 +1029,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 413,
+      "tStart": 199,
       "tCount": 4
     },
     {
@@ -1053,7 +1053,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 421,
+      "tStart": 203,
       "tCount": 3
     },
     {
@@ -1077,7 +1077,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 427,
+      "tStart": 206,
       "tCount": 6
     },
     {
@@ -1101,7 +1101,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 439,
+      "tStart": 212,
       "tCount": 5
     },
     {
@@ -1125,7 +1125,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 449,
+      "tStart": 217,
       "tCount": 4
     },
     {
@@ -1149,7 +1149,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 457,
+      "tStart": 221,
       "tCount": 6
     },
     {
@@ -1173,7 +1173,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 469,
+      "tStart": 227,
       "tCount": 2
     },
     {
@@ -1197,7 +1197,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 473,
+      "tStart": 229,
       "tCount": 2
     },
     {
@@ -1221,7 +1221,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 477,
+      "tStart": 231,
       "tCount": 5
     },
     {
@@ -1245,7 +1245,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 487,
+      "tStart": 236,
       "tCount": 5
     },
     {
@@ -1269,7 +1269,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 497,
+      "tStart": 241,
       "tCount": 3
     },
     {
@@ -1293,7 +1293,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 503,
+      "tStart": 244,
       "tCount": 7
     },
     {
@@ -1317,7 +1317,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 517,
+      "tStart": 251,
       "tCount": 3
     },
     {
@@ -1341,7 +1341,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 523,
+      "tStart": 254,
       "tCount": 4
     },
     {
@@ -1365,7 +1365,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 531,
+      "tStart": 258,
       "tCount": 6
     },
     {
@@ -1389,7 +1389,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 543,
+      "tStart": 264,
       "tCount": 2
     },
     {
@@ -1413,7 +1413,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 547,
+      "tStart": 266,
       "tCount": 5
     },
     {
@@ -1437,7 +1437,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 557,
+      "tStart": 271,
       "tCount": 4
     },
     {
@@ -1461,7 +1461,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 566,
+      "tStart": 275,
       "tCount": 3
     },
     {
@@ -1485,7 +1485,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 572,
+      "tStart": 278,
       "tCount": 7
     },
     {
@@ -1509,7 +1509,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 586,
+      "tStart": 285,
       "tCount": 10
     },
     {
@@ -1533,7 +1533,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 617,
+      "tStart": 295,
       "tCount": 6
     },
     {
@@ -1557,7 +1557,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 629,
+      "tStart": 301,
       "tCount": 4
     },
     {
@@ -1581,7 +1581,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 638,
+      "tStart": 305,
       "tCount": 6
     },
     {
@@ -1605,7 +1605,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 650,
+      "tStart": 311,
       "tCount": 7
     },
     {
@@ -1629,7 +1629,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 664,
+      "tStart": 318,
       "tCount": 7
     },
     {
@@ -1653,7 +1653,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 678,
+      "tStart": 325,
       "tCount": 9
     },
     {
@@ -1677,7 +1677,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 703,
+      "tStart": 334,
       "tCount": 7
     },
     {
@@ -1701,7 +1701,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 718,
+      "tStart": 341,
       "tCount": 2
     },
     {
@@ -1725,7 +1725,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 722,
+      "tStart": 343,
       "tCount": 2
     },
     {
@@ -1749,7 +1749,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 726,
+      "tStart": 345,
       "tCount": 7
     },
     {
@@ -1773,7 +1773,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1310,
+      "tStart": 660,
       "tCount": 4
     },
     {
@@ -1797,7 +1797,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 746,
+      "tStart": 355,
       "tCount": 9
     },
     {
@@ -1821,7 +1821,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 764,
+      "tStart": 364,
       "tCount": 2
     },
     {
@@ -1845,7 +1845,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 768,
+      "tStart": 366,
       "tCount": 3
     },
     {
@@ -1869,7 +1869,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 774,
+      "tStart": 369,
       "tCount": 3
     },
     {
@@ -1893,7 +1893,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 780,
+      "tStart": 372,
       "tCount": 4
     },
     {
@@ -1917,7 +1917,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 789,
+      "tStart": 376,
       "tCount": 7
     },
     {
@@ -1941,7 +1941,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 804,
+      "tStart": 383,
       "tCount": 6
     },
     {
@@ -1965,7 +1965,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 816,
+      "tStart": 389,
       "tCount": 3
     },
     {
@@ -1989,7 +1989,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 822,
+      "tStart": 392,
       "tCount": 4
     },
     {
@@ -2013,7 +2013,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 830,
+      "tStart": 396,
       "tCount": 5
     },
     {
@@ -2037,7 +2037,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1278,
+      "tStart": 628,
       "tCount": 6
     },
     {
@@ -2061,7 +2061,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 848,
+      "tStart": 405,
       "tCount": 6
     },
     {
@@ -2085,7 +2085,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 860,
+      "tStart": 411,
       "tCount": 8
     },
     {
@@ -2109,7 +2109,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 876,
+      "tStart": 419,
       "tCount": 5
     },
     {
@@ -2133,7 +2133,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 886,
+      "tStart": 424,
       "tCount": 5
     },
     {
@@ -2157,7 +2157,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1288,
+      "tStart": 638,
       "tCount": 7
     },
     {
@@ -2181,7 +2181,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 908,
+      "tStart": 435,
       "tCount": 5
     },
     {
@@ -2205,7 +2205,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 918,
+      "tStart": 440,
       "tCount": 3
     },
     {
@@ -2229,7 +2229,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 924,
+      "tStart": 443,
       "tCount": 6
     },
     {
@@ -2253,7 +2253,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 936,
+      "tStart": 449,
       "tCount": 7
     },
     {
@@ -2277,7 +2277,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 950,
+      "tStart": 456,
       "tCount": 5
     },
     {
@@ -2301,7 +2301,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 961,
+      "tStart": 461,
       "tCount": 6
     },
     {
@@ -2325,7 +2325,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 973,
+      "tStart": 467,
       "tCount": 5
     },
     {
@@ -2349,7 +2349,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 983,
+      "tStart": 472,
       "tCount": 5
     },
     {
@@ -2373,7 +2373,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 993,
+      "tStart": 477,
       "tCount": 5
     },
     {
@@ -2397,7 +2397,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1003,
+      "tStart": 482,
       "tCount": 6
     },
     {
@@ -2421,7 +2421,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1015,
+      "tStart": 488,
       "tCount": 2
     },
     {
@@ -2445,7 +2445,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1019,
+      "tStart": 490,
       "tCount": 2
     },
     {
@@ -2469,7 +2469,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1023,
+      "tStart": 492,
       "tCount": 5
     },
     {
@@ -2493,7 +2493,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1033,
+      "tStart": 497,
       "tCount": 6
     },
     {
@@ -2517,7 +2517,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1045,
+      "tStart": 503,
       "tCount": 2
     },
     {
@@ -2541,7 +2541,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1049,
+      "tStart": 505,
       "tCount": 4
     },
     {
@@ -2565,7 +2565,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1057,
+      "tStart": 509,
       "tCount": 7
     },
     {
@@ -2589,7 +2589,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1071,
+      "tStart": 516,
       "tCount": 6
     },
     {
@@ -2613,7 +2613,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1083,
+      "tStart": 522,
       "tCount": 6
     },
     {
@@ -2637,7 +2637,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1095,
+      "tStart": 528,
       "tCount": 3
     },
     {
@@ -2661,7 +2661,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1284,
+      "tStart": 634,
       "tCount": 4
     },
     {
@@ -2685,7 +2685,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1107,
+      "tStart": 534,
       "tCount": 3
     },
     {
@@ -2709,7 +2709,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1113,
+      "tStart": 537,
       "tCount": 7
     },
     {
@@ -2733,7 +2733,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1127,
+      "tStart": 544,
       "tCount": 3
     },
     {
@@ -2757,7 +2757,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1133,
+      "tStart": 547,
       "tCount": 6
     },
     {
@@ -2781,7 +2781,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1145,
+      "tStart": 553,
       "tCount": 4
     },
     {
@@ -2805,7 +2805,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1153,
+      "tStart": 557,
       "tCount": 6
     },
     {
@@ -2829,7 +2829,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1295,
+      "tStart": 645,
       "tCount": 7
     },
     {
@@ -2853,7 +2853,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1302,
+      "tStart": 652,
       "tCount": 8
     },
     {
@@ -2877,7 +2877,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1189,
+      "tStart": 575,
       "tCount": 6
     },
     {
@@ -2901,7 +2901,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1201,
+      "tStart": 581,
       "tCount": 3
     },
     {
@@ -2925,7 +2925,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1207,
+      "tStart": 584,
       "tCount": 3
     },
     {
@@ -2949,7 +2949,7 @@
         ]
       },
       "isBorder": false,
-      "tStart": 1213,
+      "tStart": 587,
       "tCount": 7
     },
     {
@@ -2973,7 +2973,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1227,
+      "tStart": 594,
       "tCount": 2
     },
     {
@@ -2997,7 +2997,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1231,
+      "tStart": 596,
       "tCount": 2
     },
     {
@@ -3021,7 +3021,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1235,
+      "tStart": 598,
       "tCount": 2
     },
     {
@@ -3045,7 +3045,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1239,
+      "tStart": 600,
       "tCount": 2
     },
     {
@@ -3069,7 +3069,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1243,
+      "tStart": 602,
       "tCount": 3
     },
     {
@@ -3093,7 +3093,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1249,
+      "tStart": 605,
       "tCount": 3
     },
     {
@@ -3117,7 +3117,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1255,
+      "tStart": 608,
       "tCount": 3
     },
     {
@@ -3141,7 +3141,7 @@
         ]
       },
       "isBorder": true,
-      "tStart": 1261,
+      "tStart": 611,
       "tCount": 4
     }
   ],


### PR DESCRIPTION
Reduce required number of indices in references significantly by reusing unused indices.
This method restarts the tStart every time from 0 instead of increasing with each iteration.