### PR TITLE
Add download chart to plotter

### DIFF
--- a/plotter/index.js
+++ b/plotter/index.js
@@ -35,6 +35,12 @@ const main = async () => {
     path: "fpsChart.jpg",
   });
 
+  const downloadChart = await page.$("#download");
+
+  await downloadChart.screenshot({
+    path: "downloadChart.jpg",
+  });
+
   await browser.close();
 
   snowpack.kill();

--- a/plotter/visualizer/index.html
+++ b/plotter/visualizer/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="fps"></div>
+    <div id="download"></div>
     <!-- Importing Plotly via snowpack is currently not supported -->
     <script src="https://cdn.plot.ly/plotly-1.58.4.min.js"></script>
     <script type="module" src="./visualizer.js"></script>

--- a/plotter/visualizer/visualizer.js
+++ b/plotter/visualizer/visualizer.js
@@ -1,6 +1,9 @@
 import report from "../../benchmark/tmp/report.json";
 
-const data = [
+const chartLayout = { height: 220, margin: { l: 40, r: 0, t: 0, b: 25 } };
+const chartConfig = { staticPlot: true };
+
+const fps = [
   {
     x: ["Baseline", "Optimized"],
     y: [report.baselineMedianFpsMean, report.optimizedMedianFpsMean],
@@ -16,4 +19,25 @@ const data = [
   },
 ];
 
-Plotly.newPlot("fps", data, { height: 300 }, { staticPlot: true });
+Plotly.newPlot("fps", fps, chartLayout, chartConfig);
+
+const download = [
+  {
+    x: ["Baseline", "Optimized"],
+    y: [
+      report.totalModelLoadDuration.baseline.mean,
+      report.totalModelLoadDuration.optimized.mean,
+    ],
+    error_y: {
+      type: "data",
+      array: [
+        report.totalModelLoadDuration.baseline.standardDeviation,
+        report.totalModelLoadDuration.optimized.standardDeviation,
+      ],
+      visible: true,
+    },
+    type: "bar",
+  },
+];
+
+Plotly.newPlot("download", download, chartLayout, chartConfig);


### PR DESCRIPTION
The download chart compares download times.
It's the same visualization as for the already existing fps.